### PR TITLE
Fix a memory issue

### DIFF
--- a/src/Job/DerivativeImages.php
+++ b/src/Job/DerivativeImages.php
@@ -74,7 +74,7 @@ class DerivativeImages extends AbstractJob
         $stmt = $connection->query($sql);
         $totalToProcess = $stmt->fetchColumn();
 
-        $totalResources = $api->search('media')->getTotalResults();
+        $totalResources = $api->search('media', ['limit' => 1])->getTotalResults();
 
         if (empty($totalToProcess)) {
             $logger->info(new Message(


### PR DESCRIPTION
Using the current version of the module, I get an error when calling the ```getTotalResults()``` function to count the total number of media ([src/Job/DerivativeImages.php#L77](https://github.com/Daniel-KM/Omeka-S-module-DerivativeImages/blob/master/src/Job/DerivativeImages.php#L77)).

On my database, with +300k media, I get a php error, that can be dismissed by increasing the memory_limit, but it still is very long (~4 minutes just to get this value). 

Adding a limit option to the search query let us get the number of results, but doesn't actually retrieves the results, which is the time-consuming part of the process ([application/src/Api/Adapter/AbstractEntityAdapter.php#L252-L263](https://github.com/omeka/omeka-s/blob/develop/application/src/Api/Adapter/AbstractEntityAdapter.php#L252-L263))